### PR TITLE
Fix ability to define a GUID

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           {{- end }}
           - name: COLLECTOR_POOL
             value: {{ .Values.lightstep.collector_pool | quote }}
-          {{- if .Values.lightstep.guid -}}
+          {{- if .Values.lightstep.guid }}
           - name: GUID
             value: {{ .Values.lightstep.guid }}
           {{- end }}


### PR DESCRIPTION
Prior to this change, running `helm template lightstep --values values.yaml` and having a GUID set in the values file would throw this error:

> Error: YAML parse error on lightstep/templates/deployment.yaml: error converting YAML to JSON: yaml: line 35: block sequence entries are not allowed in this context