### PR TITLE
Add container securityContext

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -25,6 +25,8 @@ spec:
       - name: lightstep-satellite
         image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
         env:
           {{- if .Values.lightstep.collector_satellite_key_secret_name }}
           - name: COLLECTOR_SATELLITE_KEY


### PR DESCRIPTION
The values.yaml has the standard entries for setting the securityContext of the container(s) but that values was not being rendered in the deployment prior to this change.