### PR TITLE
Fixes small typo and removes 'latest' version

### DIFF
--- a/charts/lightstepsatellite/Chart.yaml
+++ b/charts/lightstepsatellite/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: lightstep
 version: 1.1.3
-appVersion: latest
-description: Lightsep satellite to collect telemetry data.
+appVersion: 2020-09-24_05-22-16Z
+description: Lightstep satellite to collect telemetry data.
 home: https://lightstep.com/
 icon: https://go.lightstep.com/rs/260-KGM-472/images/logo-medium-color-400x100.jpg
 engine: gotpl

--- a/charts/lightstepsatellite/Chart.yaml
+++ b/charts/lightstepsatellite/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: lightstep
-version: 1.1.3
+version: 1.1.4
 appVersion: 2020-09-24_05-22-16Z
 description: Lightstep satellite to collect telemetry data.
 home: https://lightstep.com/

--- a/charts/lightstepsatellite/README.md
+++ b/charts/lightstepsatellite/README.md
@@ -1,8 +1,8 @@
 # lightstep
 
-![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.1.4](https://img.shields.io/badge/Version-1.1.4-informational?style=flat-square) ![AppVersion: 2020-09-24_05-22-16Z](https://img.shields.io/badge/AppVersion-2020--09--24_05--22--16Z-informational?style=flat-square)
 
-Lightsep satellite to collect telemetry data.
+Lightstep satellite to collect telemetry data.
 
 **Homepage:** <https://lightstep.com/>
 
@@ -14,6 +14,7 @@ Lightsep satellite to collect telemetry data.
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"lightstep/collector"` |  |
+| image.version | string | `"2020-09-24_05-22-16Z"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |

--- a/charts/lightstepsatellite/templates/deployment.yaml
+++ b/charts/lightstepsatellite/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: lightstep-satellite
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.version }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/lightstepsatellite/values.yaml
+++ b/charts/lightstepsatellite/values.yaml
@@ -8,6 +8,7 @@ replicaCount: 1
 
 image:
   repository: lightstep/collector
+  version: 2020-09-24_05-22-16Z
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
* There was a small typo in the description
* Removes the `latest` tag from the release

There are many reasons to avoid the `latest` tag for docker images. A production release should be idempotent so when this chart is released as `1.1.4` using the `latest` tag for Docker there is no guarantee as to which docker image gets pulled.

This PR adds a new value to the image which pins the release to a specific docker image, so `v1.1.4` will always deploy docker version `2020-09-24_05-22-16Z` no matter when it gets deployed. 
This PR also makes the image version configurable since many corporations import images to avoid deployment issues with upstream outages.