### PR TITLE
Specify prometheus scrape port

### DIFF
--- a/charts/lightstepsatellite/README.md
+++ b/charts/lightstepsatellite/README.md
@@ -43,6 +43,7 @@ Lightstep satellite to collect telemetry data.
 | lightstep.tls_cert_prefix | string | `nil` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
+| podAnnotations."prometheus.io/port" | string | `"9102"` |  |
 | podAnnotations."prometheus.io/scrape" | string | `"true"` |  |
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `1` |  |

--- a/charts/lightstepsatellite/values.yaml
+++ b/charts/lightstepsatellite/values.yaml
@@ -26,6 +26,7 @@ serviceAccount:
 
 podAnnotations:
   prometheus.io/scrape: "true"
+  prometheus.io/port: "9102"
 
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
Prior to this change, Prometheus would try to scrape from all ports the pod exposed even though only one of them provides a /metrics endpoint.