### PR TITLE
Fix issues, update images, and add new functionality

### DIFF
--- a/.github/helm-docs.sh
+++ b/.github/helm-docs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-HELM_DOCS_VERSION="1.3.0"
+HELM_DOCS_VERSION="1.5.0"
 
 # install helm-docs
 curl --silent --show-error --fail --location --output /tmp/helm-docs.tar.gz https://github.com/norwoodj/helm-docs/releases/download/v"${HELM_DOCS_VERSION}"/helm-docs_"${HELM_DOCS_VERSION}"_Linux_x86_64.tar.gz

--- a/charts/lightstepsatellite/CHANGELOG.md
+++ b/charts/lightstepsatellite/CHANGELOG.md
@@ -1,0 +1,23 @@
+## 1.2.0
+
+ENHANCEMENTS:
+
+* lightstep/collector: update image to `2021-01-26_23-02-36Z`
+* prom/statsd-exporter: update image to `v0.20.0`
+* satellite config: Satellite GUID now defaults to pod name using Downward API
+* service account: role, clusterRole, and corresponding bindings are now createable through the chart
+* kubernetes secret and configmap names: resource names are now based on Helm release name to allow multiple installs without conflict or dependency on other install's resources
+* securityContext: run user as nonroot with UID 1000
+
+BUG FIXES:
+
+* nodeSelector: deployment template properly renders if object defined for `nodeSelector`
+* affinity: deployment template properly renders if object defined for `affinity`
+* tolerations: deployment template properly renders if object defined for `tolerations`
+* securityContext: remove `drop: ["ALL"]` for capabilities
+
+BREAKING CHANGES:
+
+* satellite secret: secret name now uses the helm release name
+* statsd-mapping configmap: configmap name now uses the helm release name
+* securityContext: run user as nonroot with UID 1000

--- a/charts/lightstepsatellite/Chart.yaml
+++ b/charts/lightstepsatellite/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: lightstep
-version: 1.1.4
-appVersion: 2020-09-24_05-22-16Z
+version: 1.2.0
+appVersion: "2021-01-26_23-02-36Z"
 description: Lightstep satellite to collect telemetry data.
 home: https://lightstep.com/
 icon: https://go.lightstep.com/rs/260-KGM-472/images/logo-medium-color-400x100.jpg

--- a/charts/lightstepsatellite/README.md
+++ b/charts/lightstepsatellite/README.md
@@ -1,6 +1,6 @@
 # lightstep
 
-![Version: 1.1.4](https://img.shields.io/badge/Version-1.1.4-informational?style=flat-square) ![AppVersion: 2020-09-24_05-22-16Z](https://img.shields.io/badge/AppVersion-2020--09--24_05--22--16Z-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![AppVersion: 2021-01-26_23-02-36Z](https://img.shields.io/badge/AppVersion-2021--01--26_23--02--36Z-informational?style=flat-square)
 
 Lightstep satellite to collect telemetry data.
 
@@ -14,7 +14,7 @@ Lightstep satellite to collect telemetry data.
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"lightstep/collector"` |  |
-| image.version | string | `"2020-09-24_05-22-16Z"` |  |
+| image.version | string | `"2021-01-26_23-02-36Z"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |
@@ -33,12 +33,12 @@ Lightstep satellite to collect telemetry data.
 | lightstep.disable_access_token_checking | bool | `false` |  |
 | lightstep.grpc_plain_port | int | `8184` |  |
 | lightstep.grpc_secure_port | int | `9292` |  |
-| lightstep.guid | string | `nil` |  |
+| lightstep.guid | string | `nil` | defaults to pod's name using the Downward API |
 | lightstep.http_plain_port | int | `8181` |  |
 | lightstep.http_secure_port | int | `9191` |  |
 | lightstep.plain_port | int | `8383` |  |
-| lightstep.project_name | string | `""` |  |
-| lightstep.satelliteKey | string | `""` |  |
+| lightstep.project_name | string | `""` | REQUIRED if `lightstep.disable_access_token_checking` is `true` |
+| lightstep.satelliteKey | string | `""` | REQUIRED: your Satellite API Key - if not set, `lightstep.collector_satellite_key_secret_name` and `lightstep.collector_satellite_key_secret_key` must be set |
 | lightstep.secure_port | int | `9393` |  |
 | lightstep.tls_cert_prefix | string | `nil` |  |
 | nameOverride | string | `""` |  |
@@ -50,17 +50,29 @@ Lightstep satellite to collect telemetry data.
 | resources.limits.memory | string | `"16Gi"` |  |
 | resources.requests.cpu | int | `2` |  |
 | resources.requests.memory | string | `"16Gi"` |  |
-| securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | securityContext.readOnlyRootFilesystem | bool | `true` |  |
-| securityContext.runAsNonRoot | bool | `false` |  |
+| securityContext.runAsNonRoot | bool | `true` |  |
+| securityContext.runAsUser | int | `1000` |  |
 | service.annotations | object | `{}` |  |
-| service.grpc | bool | `false` |  |
+| service.grpc | bool | `false` | set to true if you're using GRPC in order to deploy as a headless service for better load balancing |
 | service.grpcinsecure | int | `8184` |  |
 | service.httpPort | int | `8181` |  |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.clusterRole.create | bool | `false` |  |
+| serviceAccount.clusterRole.name | string | `"lightstep-node-reader"` |  |
+| serviceAccount.clusterRoleBinding.create | bool | `false` |  |
+| serviceAccount.clusterRoleBinding.name | string | `"lightstep-read-nodes"` |  |
+| serviceAccount.clusterRoleBinding.roleRefName | string | `nil` | if not set and create is true, the `serviceAccount.clusterRole.name` is used |
+| serviceAccount.clusterRoleBinding.serviceAccountName | string | `nil` | if not set and and create is true, the generated serviceAccount name is used |
 | serviceAccount.create | bool | `false` |  |
-| serviceAccount.name | string | `nil` |  |
+| serviceAccount.name | string | `nil` | the name of the service account to use; if not set and create is true, a name is generated using the fullname template |
+| serviceAccount.role.create | bool | `false` |  |
+| serviceAccount.role.name | string | `"lightstep-pod-reader"` |  |
+| serviceAccount.roleBinding.create | bool | `false` |  |
+| serviceAccount.roleBinding.name | string | `"lightstep-read-pods"` |  |
+| serviceAccount.roleBinding.roleRefName | string | `nil` | if not set and create is true, the `serviceAccount.role.name` is used |
+| serviceAccount.roleBinding.serviceAccountName | string | `nil` | if not set and and create is true, the generated serviceAccount name is used |
 | statsd.client_prefix | string | `"client_via_canary"` |  |
 | statsd.dogStatsD | bool | `false` |  |
 | statsd.dogStatsDTags | string | `"pool:us-west-1,canary:true"` |  |
@@ -69,7 +81,7 @@ Lightstep satellite to collect telemetry data.
 | statsd.host | string | `"statsd-exporter"` |  |
 | statsd.image.pullPolicy | string | `"IfNotPresent"` |  |
 | statsd.image.repository | string | `"prom/statsd-exporter"` |  |
-| statsd.image.tag | string | `"v0.17.0"` |  |
+| statsd.image.tag | string | `"v0.20.0"` |  |
 | statsd.port | int | `9125` |  |
 | statsd.prefix | string | `"lightstep.prod.us-west-1"` |  |
 | statsd.resources | object | `{}` |  |
@@ -81,4 +93,4 @@ Lightstep satellite to collect telemetry data.
 | tolerations | list | `[]` |  |
 
 ----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.3.0](https://github.com/norwoodj/helm-docs/releases/v1.3.0)
+Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)

--- a/charts/lightstepsatellite/templates/configmap-statsd-mapping.yaml
+++ b/charts/lightstepsatellite/templates/configmap-statsd-mapping.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: statsd-mapping
+  name: {{ printf "%s-statsd-mapping" (include "lightstep.fullname" .) }}
   labels:
     {{- include "lightstep.labels" . | nindent 4 }}
 data:

--- a/charts/lightstepsatellite/templates/deployment.yaml
+++ b/charts/lightstepsatellite/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: satellitekey
-                  name: lightstep-satellite
+                  name: {{ include "lightstep.fullname" . }}
             {{- end }}
             - name: COLLECTOR_POOL
               value: {{ .Values.lightstep.collector_pool | quote }}
@@ -55,9 +55,13 @@ spec:
             - name: COLLECTOR_PROJECT_NAME
               value: {{ index .Values.lightstep.project_name}}
             {{- end }}
-            {{- if .Values.lightstep.guid }}
             - name: GUID
+            {{- if .Values.lightstep.guid }}
               value: {{ .Values.lightstep.guid }}
+            {{- else }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             {{- end }}
             - name: COLLECTOR_REPORTER_BYTES_PER_PROJECT
               value: {{ .Values.lightstep.bytes_per_project | quote }}
@@ -203,14 +207,14 @@ spec:
       {{- end }}
 
     {{- with .Values.nodeSelector }}
-    nodeSelector:
-{{- toYaml . | nindent 8 }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
     {{ end }}
-  {{- with .Values.affinity }}
-    affinity:
-{{- toYaml . | nindent 8 }}
-  {{ end }}
-  {{- with .Values.tolerations }}
-    tolerations:
-{{- toYaml . | nindent 8 }}
-  {{ end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{ end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{ end }}

--- a/charts/lightstepsatellite/templates/rolebindings.yaml
+++ b/charts/lightstepsatellite/templates/rolebindings.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.serviceAccount.role.create -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Values.serviceAccount.role.name }}
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]
+{{- end -}}
+
+{{- if .Values.serviceAccount.clusterRole.create -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.serviceAccount.clusterRole.name }}
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["nodes"]
+  verbs: ["get", "watch", "list"]
+{{- end -}}
+
+{{- if .Values.serviceAccount.roleBinding.create -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.serviceAccount.roleBinding.name }}
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ default (include "lightstep.serviceAccountName" .) .Values.serviceAccount.roleBinding.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ default .Values.serviceAccount.role.name .Values.serviceAccount.roleBinding.roleRefName }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}
+
+{{- if .Values.serviceAccount.clusterRoleBinding.create -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.serviceAccount.clusterRoleBinding.name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ default (include "lightstep.serviceAccountName" .) .Values.serviceAccount.clusterRoleBinding.serviceAccountName }}
+
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ default .Values.serviceAccount.clusterRole.name .Values.serviceAccount.clusterRoleBinding.roleRefName }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/charts/lightstepsatellite/templates/satellite-secret.yaml
+++ b/charts/lightstepsatellite/templates/satellite-secret.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: lightstep-satellite
+  name: {{ include "lightstep.fullname" . }}
   labels:
     app: "{{ template "lightstep.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/charts/lightstepsatellite/templates/serviceaccount.yaml
+++ b/charts/lightstepsatellite/templates/serviceaccount.yaml
@@ -10,4 +10,3 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end -}}
-

--- a/charts/lightstepsatellite/values.yaml
+++ b/charts/lightstepsatellite/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 
 image:
   repository: lightstep/collector
-  version: 2020-09-24_05-22-16Z
+  version: 2021-01-26_23-02-36Z
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -20,9 +20,32 @@ serviceAccount:
   create: false
   # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # -- the name of the service account to use; if not set and create is true, a name is generated using the fullname template
   name:
+  role:
+    # Specifies whether get/watch/list for pods role should be created
+    create: false
+    name: lightstep-pod-reader
+  clusterRole:
+    # Specifies whether get/watch/list for nodes clusterRole should be created
+    create: false
+    name: lightstep-node-reader
+  roleBinding:
+    # Specifies whether role should be created
+    create: false
+    name: lightstep-read-pods
+    # -- if not set and create is true, the `serviceAccount.role.name` is used
+    roleRefName:
+    # -- if not set and and create is true, the generated serviceAccount name is used
+    serviceAccountName:
+  clusterRoleBinding:
+    # Specifies whether clusterRole should be created
+    create: false
+    name: lightstep-read-nodes
+    # -- if not set and create is true, the `serviceAccount.clusterRole.name` is used
+    roleRefName:
+    # -- if not set and and create is true, the generated serviceAccount name is used
+    serviceAccountName:
 
 podAnnotations:
   prometheus.io/scrape: "true"
@@ -30,17 +53,23 @@ podAnnotations:
 podSecurityContext: {}
   # fsGroup: 2000
 
+# As of at least version 2021-01-26_23-02-36Z, `drop: ["ALL"]`
+# for securityContext.capabilities results in the lightstep/collector
+# container terminating with the following message:
+#    /bin/sh: 1: exec: /root/collector: Operation not permitted
 securityContext:
-  capabilities:
-    drop:
-      - ALL
+  # capabilities:
+  #   drop:
+  #     - ALL
   readOnlyRootFilesystem: true
-  runAsNonRoot: false
+  runAsNonRoot: true
+  runAsUser: 1000
 
 service:
   type: ClusterIP
   httpPort: 8181
-  grpc: false     #Set to true if you're using GRPC in order to deploy as a headless service for better load balancing
+  # -- set to true if you're using GRPC in order to deploy as a headless service for better load balancing
+  grpc: false
   grpcinsecure: 8184
   annotations: {}
 
@@ -61,7 +90,7 @@ ingress:
 
 lightstep:
 
-  # REQUIRED: Input your Satellite API Key
+  # -- REQUIRED: your Satellite API Key - if not set, `lightstep.collector_satellite_key_secret_name` and `lightstep.collector_satellite_key_secret_key` must be set
   satelliteKey: ""
   # OR
   collector_satellite_key_secret_name: ""
@@ -78,6 +107,7 @@ lightstep:
 
   # Single Project Mode details
   disable_access_token_checking: false
+  # -- REQUIRED if `lightstep.disable_access_token_checking` is `true`
   project_name: ""
 
   # Optional configs
@@ -85,6 +115,7 @@ lightstep:
   collector_pool: my-satellite-pool
   bytes_per_project: "1000000000"
   bytes_per_project_override:
+  # -- defaults to pod's name using the Downward API
   guid:
   diagnostic_port: 8000
   admin_plain_port: 8180
@@ -125,7 +156,7 @@ statsd:
   dogStatsDTags: "pool:us-west-1,canary:true"
   image:
     repository: prom/statsd-exporter
-    tag: v0.17.0
+    tag: v0.20.0
     pullPolicy: IfNotPresent
   securityContext:
     capabilities:


### PR DESCRIPTION
This commit incorporates a number of changes:

* Fix an alignment issue in the deployment template that prevented
`nodeSelector`, `affinity`, and `tolerations` from being defined.

* Fix default install failure due to `securityContext.capabilities.drop: ["ALL"]`
preventing the container from successfully launching by removing that setting.

* Update lightstep/collector to `2021-01-26_23-02-36Z`.

* Update prom/statsd-exporter to `v0.20.0`.

* Increase bytes_per_project default from 1GB to 4GB.

* Add role, clusterRole, roleBinding, and clusterRoleBinding resource
templates to resolve warnings logged by satellite.

* Update the statsd-mapping configmap and satellite secret names to enable
multiple releases to be installed alongside each other without conflicts or
dependencies on resources from other installs.

* Add a default GUID value of the pod name using the Downward API.

* Set security context to run as non-root user with UID 1000 by default.

* Add a CHANGELOG