### PR TITLE
Fix overzealous whitespace removal in rolebindings

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,4 +22,4 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.0.0
         env:
-          CR_TOKEN: "${{ secrets.CR_TOKEN }}"
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/charts/lightstepsatellite/Chart.yaml
+++ b/charts/lightstepsatellite/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: lightstep
-version: 1.2.1
+version: 1.2.2
 appVersion: "2021-01-26_23-02-36Z"
 description: Lightstep satellite to collect telemetry data.
 home: https://lightstep.com/

--- a/charts/lightstepsatellite/templates/rolebindings.yaml
+++ b/charts/lightstepsatellite/templates/rolebindings.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.role.create -}}
+{{- if .Values.serviceAccount.role.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -9,9 +9,9 @@ rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["pods"]
   verbs: ["get", "watch", "list"]
-{{- end -}}
+{{- end }}
 
-{{- if .Values.serviceAccount.clusterRole.create -}}
+{{- if .Values.serviceAccount.clusterRole.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -21,9 +21,9 @@ rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["nodes"]
   verbs: ["get", "watch", "list"]
-{{- end -}}
+{{- end }}
 
-{{- if .Values.serviceAccount.roleBinding.create -}}
+{{- if .Values.serviceAccount.roleBinding.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -38,9 +38,9 @@ roleRef:
   kind: Role
   name: {{ default .Values.serviceAccount.role.name .Values.serviceAccount.roleBinding.roleRefName }}
   apiGroup: rbac.authorization.k8s.io
-{{- end -}}
+{{- end }}
 
-{{- if .Values.serviceAccount.clusterRoleBinding.create -}}
+{{- if .Values.serviceAccount.clusterRoleBinding.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -49,10 +49,9 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ default (include "lightstep.serviceAccountName" .) .Values.serviceAccount.clusterRoleBinding.serviceAccountName }}
-
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: {{ default .Values.serviceAccount.clusterRole.name .Values.serviceAccount.clusterRoleBinding.roleRefName }}
   apiGroup: rbac.authorization.k8s.io
-{{- end -}}
+{{- end }}


### PR DESCRIPTION
While working on my previous PR, I was lazy and just copied a handy `{{- if -}}` directive, not paying attention to the fact that this had a `-` on both sides of the directive which breaks the rendered yaml. This PR fixes that and appropriately bumps the version of the chart.