### PR TITLE
Changed default to run under LS serviceAccount

### DIFF
--- a/charts/lightstepsatellite/CHANGELOG.md
+++ b/charts/lightstepsatellite/CHANGELOG.md
@@ -1,8 +1,16 @@
+##1.2.4
+
+ENHANCEMENTS:
+
+* Changed the default serviceaccpimt to be the Lightstep provisioned serviceaccount. This should enable easier 'default' deployments
+
+
 ##1.2.3
 
 ENHANCEMENTS:
 
 * Added a service for statsD-exporter
+* Changed default service type to LoadBalancer in order to provide a publicly accessible endpoint
 * Updated REAME with accurate metrics functionality
 * Added another maintainer
 

--- a/charts/lightstepsatellite/Chart.yaml
+++ b/charts/lightstepsatellite/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: lightstep
-version: 1.2.3
+version: 1.2.4
 appVersion: "2021-01-26_23-02-36Z"
 description: Lightstep satellite to collect telemetry data.
 home: https://lightstep.com/

--- a/charts/lightstepsatellite/values.yaml
+++ b/charts/lightstepsatellite/values.yaml
@@ -17,22 +17,22 @@ fullnameOverride: ""
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # -- the name of the service account to use; if not set and create is true, a name is generated using the fullname template
   name:
   role:
     # Specifies whether get/watch/list for pods role should be created
-    create: false
+    create: true
     name: lightstep-pod-reader
   clusterRole:
     # Specifies whether get/watch/list for nodes clusterRole should be created
-    create: false
+    create: true
     name: lightstep-node-reader
   roleBinding:
     # Specifies whether role should be created
-    create: false
+    create: true
     name: lightstep-read-pods
     # -- if not set and create is true, the `serviceAccount.role.name` is used
     roleRefName:
@@ -40,7 +40,7 @@ serviceAccount:
     serviceAccountName:
   clusterRoleBinding:
     # Specifies whether clusterRole should be created
-    create: false
+    create: true
     name: lightstep-read-nodes
     # -- if not set and create is true, the `serviceAccount.clusterRole.name` is used
     roleRefName:
@@ -74,7 +74,7 @@ service:
   grpcinsecure: 8184
   annotations: {}
   # -- set to true to create a service for the statsd exporter. This endpoint will yield a Prometheus endpoint to scrape
-  metricExporter: false
+  metricExporter: true
   metricServiceType: LoadBalancer
   # -- This should be the same as the podAnnotations.prometheus.io/port value
   promScrapeEndpoint: 9102


### PR DESCRIPTION
Changed service account defaults to true. This will run the service as a Lightstep created serviceAccount by default and better ensure permissions required are set.